### PR TITLE
Ljh/post Contoller 생성 후 PostMan으로 CRUD 성공 테스트 진행 

### DIFF
--- a/src/main/java/kr/co/skudeview/controller/PostApiController.java
+++ b/src/main/java/kr/co/skudeview/controller/PostApiController.java
@@ -1,0 +1,64 @@
+package kr.co.skudeview.controller;
+
+import kr.co.skudeview.repository.PostRepository;
+import kr.co.skudeview.service.PostService;
+import kr.co.skudeview.service.dto.request.PostRequestDto;
+import kr.co.skudeview.service.dto.response.PostResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class PostApiController {
+
+    private final PostService postService;
+
+    /**
+     * 게시글 생성
+     */
+    @PostMapping("/post")
+    public Long savePost(@RequestBody PostRequestDto.CREATE createParams) {
+        Long postId = postService.createPost(createParams);
+        return postId;
+    }
+
+
+    /**
+     * 게시글 리스트 조회
+     */
+    @GetMapping("/post")
+    public List<PostResponseDto.READ> findAllPost() {
+        List<PostResponseDto.READ> posts = postService.getAllPosts();
+        return posts;
+
+    }
+
+    /**
+     * 게시글 수정
+     */
+    @PatchMapping("/post/{id}")
+    public Long updatePost(@PathVariable Long id, @RequestBody PostRequestDto.UPDATE updateParams) {
+        Long postId = postService.updatePost(id, updateParams);
+        return postId;
+    }
+    /**
+     * 게시글 삭제
+     */
+    @DeleteMapping("/post/{id}")
+    public Long deletePost(@PathVariable Long id) {
+        Long postId = postService.deletePost(id);
+        return postId;
+    }
+
+    /**
+     * 게시글 상세정보 조회
+     */
+    @GetMapping("/post/{id}")
+    public PostResponseDto.READ findPostDetail(@PathVariable Long id) {
+        PostResponseDto.READ postDetail = postService.getPostDetail(id);
+        return postDetail;
+    }
+}

--- a/src/main/java/kr/co/skudeview/domain/BaseEntity.java
+++ b/src/main/java/kr/co/skudeview/domain/BaseEntity.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -12,6 +13,7 @@ import java.time.LocalDateTime;
 
 @MappedSuperclass
 @Getter
+@Setter //delete_at 값을 Y로 바꾸기 위한 setter 추후 상의할 예정
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
 

--- a/src/main/java/kr/co/skudeview/domain/Post.java
+++ b/src/main/java/kr/co/skudeview/domain/Post.java
@@ -71,4 +71,10 @@ public class Post extends BaseEntity {
         this.likeCount++;
     }
 
+    /**
+     * 게시글 삭제
+     */
+    public void delete() {
+       this.setDeleteAt("Y");
+        }
 }

--- a/src/main/java/kr/co/skudeview/service/PostServiceImpl.java
+++ b/src/main/java/kr/co/skudeview/service/PostServiceImpl.java
@@ -46,7 +46,7 @@ public class PostServiceImpl implements PostService {
     @Transactional
     public Long deletePost(Long postId) {
         Post post = postRepository.findById(postId).orElseThrow(() -> new RuntimeException());
-        postRepository.delete(post);
+        post.getDeleteAt().replace('N','Y');
         return post.getId();
     }
 

--- a/src/main/java/kr/co/skudeview/service/PostServiceImpl.java
+++ b/src/main/java/kr/co/skudeview/service/PostServiceImpl.java
@@ -29,8 +29,7 @@ public class PostServiceImpl implements PostService {
 
     @Override
     public List<PostResponseDto.READ> getAllPosts() {
-        Sort sort = Sort.by(Sort.Direction.DESC,"id","regDate");
-        List<Post> list = postRepository.findAll(sort);
+        List<Post> list = postRepository.findAll(); //추후 삭제 여부에 따른 동적쿼리로 변경
         return list.stream().map(PostResponseDto.READ::new).collect(Collectors.toList());
     }
 

--- a/src/main/java/kr/co/skudeview/service/PostServiceImpl.java
+++ b/src/main/java/kr/co/skudeview/service/PostServiceImpl.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -30,7 +31,20 @@ public class PostServiceImpl implements PostService {
     @Override
     public List<PostResponseDto.READ> getAllPosts() {
         List<Post> list = postRepository.findAll(); //추후 삭제 여부에 따른 동적쿼리로 변경
-        return list.stream().map(PostResponseDto.READ::new).collect(Collectors.toList());
+        List<PostResponseDto.READ> posts = new ArrayList<>();
+        for (Post post : list) {
+            PostResponseDto.READ dto = PostResponseDto.READ.builder()
+                    .title(post.getTitle())
+                    .postCategory(post.getPostCategory())
+                    .postId(post.getId())
+                    .viewCount(post.getViewCount())
+                    .likeCount(post.getLikeCount())
+                    .memberEmail(post.getMember().getEmail())
+                    .content(post.getContent())
+                    .build();
+            posts.add(dto);
+        }
+        return posts;
     }
 
     @Override
@@ -45,7 +59,7 @@ public class PostServiceImpl implements PostService {
     @Transactional
     public Long deletePost(Long postId) {
         Post post = postRepository.findById(postId).orElseThrow(() -> new RuntimeException());
-        post.getDeleteAt().replace('N','Y');
+        post.delete();
         return post.getId();
     }
 


### PR DESCRIPTION
1. post Contoller 생성 후 PostMan으로 CRUD 성공 테스트 진행 (추후에 실패 테스트 추가 예정)
2. BaseEntity의 delete_at 값을 Y로 바꾸기 위한 @setter추가(상의 후 결정)
3. Post entity에 논리적 삭제를 위한 delete() 추가
4. Unmapped target 이슈로 인해 PostServiceImpl.getAllPosts()의 로직 변경 (Mapper 공부 후 수정 예정)