### PR TITLE
Jsh/member

### DIFF
--- a/src/main/java/kr/co/skudeview/infra/model/ResponseStatus.java
+++ b/src/main/java/kr/co/skudeview/infra/model/ResponseStatus.java
@@ -32,7 +32,7 @@ public enum ResponseStatus {
     FAIL_MEMBER_ROLE_NOT_FOUND("클라이언트가 요청한 소유자의 권한을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     FAIL_MEMBER_EMAIL_DUPLICATED("클라이언트가 요청한 이메일이 중복되었습니다.", HttpStatus.BAD_REQUEST),
     FAIL_MEMBER_TELEPHONE_DUPLICATED("클라이언트가 요청한 전화번호가 중복되었습니다.", HttpStatus.BAD_REQUEST),
-    FAIL_MEMBER_NICKNAME_DUPLICATED("클라이언트가 요청한 전화번호가 중복되었습니다.", HttpStatus.BAD_REQUEST),
+    FAIL_MEMBER_NICKNAME_DUPLICATED("클라이언트가 요청한 닉네임이 중복되었습니다.", HttpStatus.BAD_REQUEST),
     FAIL_MEMBER_PASSWORD_NOT_MATCHED("클라이언트가 입력한 비밀번호가 소유자의 비밀번호와 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
 
     // Post

--- a/src/main/java/kr/co/skudeview/repository/MemberSkillRepository.java
+++ b/src/main/java/kr/co/skudeview/repository/MemberSkillRepository.java
@@ -1,0 +1,14 @@
+package kr.co.skudeview.repository;
+
+import kr.co.skudeview.domain.MemberSkill;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface MemberSkillRepository extends JpaRepository<MemberSkill, Long> {
+
+    List<MemberSkill> findMemberSkillByMember_IdAndDeleteAtFalse(Long memberId);
+
+}

--- a/src/main/java/kr/co/skudeview/service/MemberService.java
+++ b/src/main/java/kr/co/skudeview/service/MemberService.java
@@ -1,9 +1,14 @@
 package kr.co.skudeview.service;
 
+import kr.co.skudeview.domain.Member;
+import kr.co.skudeview.domain.enums.Gender;
+import kr.co.skudeview.domain.enums.Role;
 import kr.co.skudeview.service.dto.request.MemberRequestDto;
 import kr.co.skudeview.service.dto.response.MemberResponseDto;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 public interface MemberService {
 
@@ -16,6 +21,38 @@ public interface MemberService {
     void updateMember(MemberRequestDto.UPDATE update);
 
     void deleteMember(Long id);
+
+    Set<String> getSkillsNameByMember(Member member);
+
+    default Member toEntity(MemberRequestDto.CREATE create) {
+        return Member.builder()
+                .email(create.getEmail())
+                .password(create.getPassword())
+                .name(create.getName())
+                .nickname(create.getNickname())
+                .telephone(create.getTelephone())
+                .address(create.getAddress())
+                .birthDate(create.getBirthDate())
+                .gender(Gender.valueOf(create.getGender()))
+                .role(Role.valueOf(create.getRole()))
+                .memberSkills(Collections.emptyList())
+                .build();
+    }
+
+    default MemberResponseDto.READ toReadDto(Member member) {
+        return MemberResponseDto.READ.builder()
+                .memberId(member.getId())
+                .email(member.getEmail())
+                .name(member.getName())
+                .nickname(member.getNickname())
+                .telephone(member.getTelephone())
+                .address(member.getAddress())
+                .birthDate(member.getBirthDate())
+                .gender(String.valueOf(member.getGender()))
+                .role(String.valueOf(member.getGender()))
+                .skillName(getSkillsNameByMember(member))
+                .build();
+    }
 
 }
 

--- a/src/main/java/kr/co/skudeview/service/dto/response/MemberResponseDto.java
+++ b/src/main/java/kr/co/skudeview/service/dto/response/MemberResponseDto.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
-import java.util.List;
+import java.util.Set;
 
 public class MemberResponseDto {
 
@@ -34,7 +34,7 @@ public class MemberResponseDto {
 
         private String role;
 
-        private List<String> skillName;
+        private Set<String> skillName;
     }
 
 }

--- a/src/main/java/kr/co/skudeview/service/mapper/MemberMapper.java
+++ b/src/main/java/kr/co/skudeview/service/mapper/MemberMapper.java
@@ -13,9 +13,9 @@ import java.util.List;
 @Mapper(componentModel = "spring")
 public interface MemberMapper {
 
-    Member toEntity(MemberRequestDto.CREATE create, List<MemberSkill> memberSkills);
-
-    @Mapping(target = "memberId", source = "member.id")
-    @Mapping(target="skillName", source = "memberSkills")
-    MemberResponseDto.READ toReadDto(Member member, List<String> memberSkills);
+//    Member toEntity(MemberRequestDto.CREATE create, List<MemberSkill> memberSkills);
+//
+//    @Mapping(target = "memberId", source = "member.id")
+//    @Mapping(target="skillName", source = "memberSkills")
+//    MemberResponseDto.READ toReadDto(Member member, List<String> memberSkills);
 }

--- a/src/main/java/kr/co/skudeview/service/mapper/MemberSkillMapper.java
+++ b/src/main/java/kr/co/skudeview/service/mapper/MemberSkillMapper.java
@@ -9,6 +9,6 @@ import org.mapstruct.Mapping;
 @Mapper(componentModel = "spring")
 public interface MemberSkillMapper {
 
-    MemberSkill toEntity(Skill skill, Member member);
+//    MemberSkill toEntity(Skill skill, Member member);
 
 }


### PR DESCRIPTION
1. status 에서 nickname 쪽 중복 message에 오타 수정
2. mapper 인터페이스 사용해주지 않을 것 -> 우선 파일 삭제는 하지 않고 주석처리
3. update와 delete 시에 연관 테이블인 memberSkill에 제대로 반영되지 않던 것 로직 수정을 통해 해결
 + response시에 list를 사용하여 중복이 일어날 수 있었지만 이를 방지하기 위해서 set으로 바꿔 사용