### PR TITLE
Jsh/report

### DIFF
--- a/src/main/java/kr/co/skudeview/controller/ReportApiController.java
+++ b/src/main/java/kr/co/skudeview/controller/ReportApiController.java
@@ -1,0 +1,80 @@
+package kr.co.skudeview.controller;
+
+import jakarta.validation.Valid;
+import kr.co.skudeview.infra.model.ResponseFormat;
+import kr.co.skudeview.infra.model.ResponseStatus;
+import kr.co.skudeview.service.ReportService;
+import kr.co.skudeview.service.dto.request.ReportRequestDto;
+import kr.co.skudeview.service.dto.response.ReportResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class ReportApiController {
+
+    /*
+    신고의 경우 수정이나 철회가 불가능하게 하는 이유
+     : 일반적으로 이러한 정책은 신고 프로세스의 신뢰성과 신뢰를 유지하기 위함
+
+    1. 신고의 불변성 유지: 수정이나 철회를 허용한다면, 이는 신고한 내용을 언제든지 변경할 수 있다는 의미입니다.
+    그러면 신고 시점의 상황이 변형되어 사실과 다른 정보를 제공하는 등 혼란을 초래할 수 있습니다.
+    따라서 신고가 접수되고 확인된 후에는 내용을 수정할 수 없도록 하는 것이 일반적입니다.
+
+    2. 중요한 사안에 대한 신뢰성 유지: 신고는 종종 심각한 문제나 위협을 보고하는 수단입니다.
+    예를 들어, 범죄 신고, 폭력적인 행동 신고, 사회적으로 민감한 내용 신고 등이 있습니다.
+    이러한 신고는 신속하고 정확한 조치를 필요로 하며, 이를 위해서는 신고한 내용이 수정되거나 철회되지 않아야 합니다.
+
+    3. 남용 방지: 수정이나 철회가 가능하다면, 악의적인 사용자가 신고를 남기고 다른 사람을 괴롭히거나 혼란을 일으킬 수 있습니다.
+    이를 막기 위해 일단 신고가 접수되면 수정이나 철회가 불가능하게 하는 것이 좋은 방법입니다.
+     */
+
+    private final ReportService reportService;
+
+    /**
+     * Create Report API
+     * @param postId
+     * @param create
+     * @return ResponseStatus.SUCCESS_CREATE + Void
+     */
+    @PostMapping("/report/{postId}")
+    public ResponseFormat<Void> createReport(@PathVariable Long postId, @RequestBody @Valid ReportRequestDto.CREATE create) {
+        reportService.createReport(postId, create);
+
+        return ResponseFormat.success(ResponseStatus.SUCCESS_CREATE);
+    }
+
+    /**
+     * Read Report API - postId 값으로 다중 조회
+     * @param postId
+     * @return ResponseStatus.SUCCESS_OK + List<ReportResponseDto.READ>
+     */
+    @GetMapping("/report/{postId}")
+    public ResponseFormat<List<ReportResponseDto.READ>> getAllReportsByPost(@PathVariable Long postId) {
+        return ResponseFormat.successWithData(ResponseStatus.SUCCESS_OK, reportService.getAllReportsByPost(postId));
+    }
+
+    /**
+     * Read Report API - reportId 값으로 단일 조회
+     * @param postId
+     * @param reportId
+     * @return ResponseStatus.SUCCESS_OK + ReportResponseDto.READ
+     */
+    @GetMapping("/report/{postId}/{reportId}")
+    public ResponseFormat<ReportResponseDto.READ> getReportDetail(@PathVariable Long postId, @PathVariable Long reportId) {
+        return ResponseFormat.successWithData(ResponseStatus.SUCCESS_OK, reportService.getReportDetail(reportId));
+    }
+
+    /**
+     * Read Report API - 모듬 Report 다중 조회
+     * @return ResponseStatus.SUCCESS_OK + List<ReportResponseDto.READ>
+     */
+    @GetMapping("/report")
+    public ResponseFormat<List<ReportResponseDto.READ>> getAllReports() {
+        return ResponseFormat.successWithData(ResponseStatus.SUCCESS_OK, reportService.getAllReports());
+    }
+
+}

--- a/src/main/java/kr/co/skudeview/infra/model/ResponseStatus.java
+++ b/src/main/java/kr/co/skudeview/infra/model/ResponseStatus.java
@@ -39,13 +39,13 @@ public enum ResponseStatus {
     FAIL_POST_NOT_FOUND("클라이언트가 요청한 게시글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     FAIL_POST_CATEGORY_NOT_FOUND("클라이언트가 요청한 게시글의 카테고리를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 
-
     // Reply
     FAIL_REPLY_NOT_FOUND("클라이언트가 요청한 댓글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 
     // Report
+    FAIL_REPORT_NOT_FOUND("클라이언트가 요청한 신고를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    FAIL_REPORT_DUPLICATED("클라이언트가 요청한 신고는 이미 접수되었습니다. 중복 신고는 불가능합나디.", HttpStatus.BAD_REQUEST),
     FAIL_REPORT_CATEGORY_NOT_FOUND("클라이언트가 요청한 신고의 카테고리를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-
 
     // Skill
     FAIL_SKILL_NOT_FOUND("클라이언트가 요청한 스킬을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),

--- a/src/main/java/kr/co/skudeview/repository/ReportRepository.java
+++ b/src/main/java/kr/co/skudeview/repository/ReportRepository.java
@@ -1,0 +1,24 @@
+package kr.co.skudeview.repository;
+
+import kr.co.skudeview.domain.Report;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ReportRepository extends JpaRepository<Report, Long> {
+
+    // reportId 값으로 report 단일 조회 + 삭제되지 않은 report
+    Optional<Report> findReportByIdAndDeleteAtFalse(Long id);
+
+    // portId 값으로 report 다중 조회 + 삭제되지 않은 report
+    List<Report> findReportsByPostIdAndDeleteAtFalse(Long postId);
+
+    // report 다중 조회 + 삭제되지 않은 report
+    List<Report> findReportsByDeleteAtFalse();
+
+    // postId, memberId를 이용하여 이미 신고한 것인지 체크
+    boolean existsReportByPost_IdAndMember_IdAndDeleteAtFalse(Long postId, Long memberId);
+}

--- a/src/main/java/kr/co/skudeview/service/ReportService.java
+++ b/src/main/java/kr/co/skudeview/service/ReportService.java
@@ -1,0 +1,45 @@
+package kr.co.skudeview.service;
+
+import kr.co.skudeview.domain.Member;
+import kr.co.skudeview.domain.Post;
+import kr.co.skudeview.domain.Report;
+import kr.co.skudeview.domain.enums.ReportCategory;
+import kr.co.skudeview.service.dto.request.ReportRequestDto;
+import kr.co.skudeview.service.dto.response.ReportResponseDto;
+
+import java.util.List;
+
+public interface ReportService {
+
+    void createReport(Long postId, ReportRequestDto.CREATE create);
+
+    List<ReportResponseDto.READ> getAllReportsByPost(Long postId);
+
+    ReportResponseDto.READ getReportDetail(Long reportId);
+
+    List<ReportResponseDto.READ> getAllReports();
+
+    default Report toEntity(ReportRequestDto.CREATE create, Member reporter, Post reportPost) {
+        return Report.builder()
+                .member(reporter)
+                .post(reportPost)
+                .reportCategory(ReportCategory.valueOf(create.getPostCategory()))
+                .title(create.getTitle())
+                .description(create.getDescription())
+                .build();
+    }
+
+    default ReportResponseDto.READ toReadDto(Report report) {
+        return ReportResponseDto.READ.builder()
+                .reportId(report.getId())
+                .postId(report.getPost().getId())
+                .memberEmail(report.getMember().getEmail())
+                .memberName(report.getMember().getName())
+                .postCategory(String.valueOf(report.getReportCategory()))
+                .postTitle(report.getPost().getTitle())
+                .title(report.getTitle())
+                .description(report.getDescription())
+                .build();
+
+    }
+}

--- a/src/main/java/kr/co/skudeview/service/ReportServiceImpl.java
+++ b/src/main/java/kr/co/skudeview/service/ReportServiceImpl.java
@@ -1,0 +1,103 @@
+package kr.co.skudeview.service;
+
+import jakarta.transaction.Transactional;
+import kr.co.skudeview.domain.Member;
+import kr.co.skudeview.domain.Post;
+import kr.co.skudeview.domain.Report;
+import kr.co.skudeview.domain.enums.ReportCategory;
+import kr.co.skudeview.infra.exception.DuplicatedException;
+import kr.co.skudeview.infra.exception.NotFoundException;
+import kr.co.skudeview.infra.model.ResponseStatus;
+import kr.co.skudeview.repository.MemberRepository;
+import kr.co.skudeview.repository.PostRepository;
+import kr.co.skudeview.repository.ReportRepository;
+import kr.co.skudeview.service.dto.request.ReportRequestDto;
+import kr.co.skudeview.service.dto.response.ReportResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ReportServiceImpl implements ReportService {
+
+    private final ReportRepository reportRepository;
+
+    private final MemberRepository memberRepository;
+
+    private final PostRepository postRepository;
+
+    @Override
+    @Transactional
+    public void createReport(Long postId, ReportRequestDto.CREATE create) {
+        isReportCategory(create.getPostCategory());
+
+        Optional<Member> findMember = memberRepository.findMemberByEmailAndDeleteAtFalse(create.getMemberEmail());
+        isMember(findMember);
+
+        Optional<Post> findPost = postRepository.findPostByIdAndDeleteAtFalse(postId);
+        isPost(findPost);
+
+        isReportDuplicated(findPost.get().getId(), findMember.get().getId());
+
+        reportRepository.save(toEntity(create, findMember.get(), findPost.get()));
+    }
+
+    @Override
+    public List<ReportResponseDto.READ> getAllReportsByPost(Long postId) {
+        List<Report> reports = reportRepository.findReportsByPostIdAndDeleteAtFalse(postId);
+        return reports.stream()
+                .map(this::toReadDto)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public ReportResponseDto.READ getReportDetail(Long reportId) {
+        Optional<Report> report = reportRepository.findReportByIdAndDeleteAtFalse(reportId);
+
+        isReport(report);
+
+        return toReadDto(report.get());
+    }
+
+    @Override
+    public List<ReportResponseDto.READ> getAllReports() {
+        List<Report> reports = reportRepository.findReportsByDeleteAtFalse();
+        return reports.stream()
+                .map(this::toReadDto)
+                .collect(Collectors.toList());
+    }
+
+
+    private void isMember(Optional<Member> member) {
+        if (member.isEmpty()) {
+            throw new NotFoundException(ResponseStatus.FAIL_MEMBER_NOT_FOUND);
+        }
+    }
+
+    private void isPost(Optional<Post> post) {
+        if (post.isEmpty()) {
+            throw new NotFoundException(ResponseStatus.FAIL_POST_NOT_FOUND);
+        }
+    }
+
+    private void isReport(Optional<Report> report) {
+        if (report.isEmpty()) {
+            throw new NotFoundException(ResponseStatus.FAIL_REPORT_NOT_FOUND);
+        }
+    }
+
+    private void isReportDuplicated(Long postId, Long memberId) {
+        if (reportRepository.existsReportByPost_IdAndMember_IdAndDeleteAtFalse(postId, memberId)) {
+            throw new DuplicatedException(ResponseStatus.FAIL_REPORT_DUPLICATED);
+        }
+    }
+
+    private void isReportCategory(String reportCategory) {
+        ReportCategory.of(reportCategory);
+    }
+
+}

--- a/src/main/java/kr/co/skudeview/service/dto/request/ReportRequestDto.java
+++ b/src/main/java/kr/co/skudeview/service/dto/request/ReportRequestDto.java
@@ -1,0 +1,27 @@
+package kr.co.skudeview.service.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ReportRequestDto {
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    @Builder
+    public static class CREATE {
+
+        private Long postId;
+
+        private String memberEmail;
+
+        private String postCategory;
+
+        private String title;
+
+        private String description;
+    }
+
+}

--- a/src/main/java/kr/co/skudeview/service/dto/response/ReportResponseDto.java
+++ b/src/main/java/kr/co/skudeview/service/dto/response/ReportResponseDto.java
@@ -1,0 +1,33 @@
+package kr.co.skudeview.service.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ReportResponseDto {
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    @Builder
+    public static class READ {
+
+        private Long reportId;
+
+        private Long postId;
+
+        private String memberEmail;
+
+        private String memberName;
+
+        private String postCategory;
+
+        private String postTitle;
+
+        private String title;
+
+        private String description;
+    }
+
+}


### PR DESCRIPTION
신고의 경우 수정이나 철회가 불가능하게 하는 이유
1. 신고의 불변성 유지: 수정이나 철회를 허용한다면, 이는 신고한 내용을 언제든지 변경할 수 있다는 의미입니다.
    그러면 신고 시점의 상황이 변형되어 사실과 다른 정보를 제공하는 등 혼란을 초래할 수 있습니다.
    따라서 신고가 접수되고 확인된 후에는 내용을 수정할 수 없도록 하는 것이 일반적입니다.
2. 중요한 사안에 대한 신뢰성 유지: 신고는 종종 심각한 문제나 위협을 보고하는 수단입니다.
    예를 들어, 범죄 신고, 폭력적인 행동 신고, 사회적으로 민감한 내용 신고 등이 있습니다.
    이러한 신고는 신속하고 정확한 조치를 필요로 하며, 이를 위해서는 신고한 내용이 수정되거나 철회되지 않아야 합니다.
 3. 남용 방지: 수정이나 철회가 가능하다면, 악의적인 사용자가 신고를 남기고 다른 사람을 괴롭히거나 혼란을 일으킬 수 있습니다.
    이를 막기 위해 일단 신고가 접수되면 수정이나 철회가 불가능하게 하는 것이 좋은 방법입니다.
    
이러한 이유로 report에 create, read만 가능하도록 구현
    