### PR TITLE
Ljh/querydsl

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,8 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.0.6'
     id 'io.spring.dependency-management' version '1.1.0'
+    //querydsl
+    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 group = 'kr.co'
@@ -52,8 +54,28 @@ dependencies {
     //JSON
     implementation 'com.googlecode.json-simple:json-simple:1.1.1'
 
+    //QueryDsl
+    implementation 'com.querydsl:querydsl-jpa'
+
 }
 
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+//querydsl 추가 시작
+def querydslDir = "$buildDir/generated/querydsl"
+querydsl {
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
+sourceSets {
+    main.java.srcDir querydslDir
+}
+configurations {
+    querydsl.extendsFrom compileClasspath
+}
+compileQuerydsl {
+    options.annotationProcessorPath = configurations.querydsl
+}
+//querydsl 추가 끝

--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,6 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.0.6'
     id 'io.spring.dependency-management' version '1.1.0'
-    //querydsl
-    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 group = 'kr.co'
@@ -55,7 +53,11 @@ dependencies {
     implementation 'com.googlecode.json-simple:json-simple:1.1.1'
 
     //QueryDsl
-    implementation 'com.querydsl:querydsl-jpa'
+
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
 }
 
@@ -64,18 +66,11 @@ tasks.named('test') {
 }
 
 //querydsl 추가 시작
-def querydslDir = "$buildDir/generated/querydsl"
-querydsl {
-    jpa = true
-    querydslSourcesDir = querydslDir
+def querydslSrcDir = 'src/main/generated'
+clean {
+    delete file(querydslSrcDir)
 }
-sourceSets {
-    main.java.srcDir querydslDir
-}
-configurations {
-    querydsl.extendsFrom compileClasspath
-}
-compileQuerydsl {
-    options.annotationProcessorPath = configurations.querydsl
+tasks.withType(JavaCompile) {
+    options.generatedSourceOutputDirectory = file(querydslSrcDir)
 }
 //querydsl 추가 끝

--- a/src/main/generated/kr/co/skudeview/domain/QBaseEntity.java
+++ b/src/main/generated/kr/co/skudeview/domain/QBaseEntity.java
@@ -1,0 +1,41 @@
+package kr.co.skudeview.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QBaseEntity is a Querydsl query type for BaseEntity
+ */
+@Generated("com.querydsl.codegen.DefaultSupertypeSerializer")
+public class QBaseEntity extends EntityPathBase<BaseEntity> {
+
+    private static final long serialVersionUID = -860759720L;
+
+    public static final QBaseEntity baseEntity = new QBaseEntity("baseEntity");
+
+    public final BooleanPath deleteAt = createBoolean("deleteAt");
+
+    public final DateTimePath<java.time.LocalDateTime> modDate = createDateTime("modDate", java.time.LocalDateTime.class);
+
+    public final DateTimePath<java.time.LocalDateTime> regDate = createDateTime("regDate", java.time.LocalDateTime.class);
+
+    public QBaseEntity(String variable) {
+        super(BaseEntity.class, forVariable(variable));
+    }
+
+    public QBaseEntity(Path<? extends BaseEntity> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QBaseEntity(PathMetadata metadata) {
+        super(BaseEntity.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/kr/co/skudeview/domain/QCompany.java
+++ b/src/main/generated/kr/co/skudeview/domain/QCompany.java
@@ -1,0 +1,72 @@
+package kr.co.skudeview.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QCompany is a Querydsl query type for Company
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QCompany extends EntityPathBase<Company> {
+
+    private static final long serialVersionUID = 1894809529L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QCompany company = new QCompany("company");
+
+    public final QBaseEntity _super = new QBaseEntity(this);
+
+    public final StringPath companyName = createString("companyName");
+
+    //inherited
+    public final BooleanPath deleteAt = _super.deleteAt;
+
+    public final StringPath description = createString("description");
+
+    public final DatePath<java.time.LocalDate> endDate = createDate("endDate", java.time.LocalDate.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final QMember member;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modDate = _super.modDate;
+
+    public final StringPath position = createString("position");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> regDate = _super.regDate;
+
+    public final DatePath<java.time.LocalDate> startDate = createDate("startDate", java.time.LocalDate.class);
+
+    public QCompany(String variable) {
+        this(Company.class, forVariable(variable), INITS);
+    }
+
+    public QCompany(Path<? extends Company> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QCompany(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QCompany(PathMetadata metadata, PathInits inits) {
+        this(Company.class, metadata, inits);
+    }
+
+    public QCompany(Class<? extends Company> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.member = inits.isInitialized("member") ? new QMember(forProperty("member")) : null;
+    }
+
+}
+

--- a/src/main/generated/kr/co/skudeview/domain/QFollow.java
+++ b/src/main/generated/kr/co/skudeview/domain/QFollow.java
@@ -1,0 +1,65 @@
+package kr.co.skudeview.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QFollow is a Querydsl query type for Follow
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QFollow extends EntityPathBase<Follow> {
+
+    private static final long serialVersionUID = 8429813L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QFollow follow = new QFollow("follow");
+
+    public final QBaseEntity _super = new QBaseEntity(this);
+
+    //inherited
+    public final BooleanPath deleteAt = _super.deleteAt;
+
+    public final QMember fromMember;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modDate = _super.modDate;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> regDate = _super.regDate;
+
+    public final QMember toMember;
+
+    public QFollow(String variable) {
+        this(Follow.class, forVariable(variable), INITS);
+    }
+
+    public QFollow(Path<? extends Follow> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QFollow(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QFollow(PathMetadata metadata, PathInits inits) {
+        this(Follow.class, metadata, inits);
+    }
+
+    public QFollow(Class<? extends Follow> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.fromMember = inits.isInitialized("fromMember") ? new QMember(forProperty("fromMember")) : null;
+        this.toMember = inits.isInitialized("toMember") ? new QMember(forProperty("toMember")) : null;
+    }
+
+}
+

--- a/src/main/generated/kr/co/skudeview/domain/QImage.java
+++ b/src/main/generated/kr/co/skudeview/domain/QImage.java
@@ -1,0 +1,68 @@
+package kr.co.skudeview.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QImage is a Querydsl query type for Image
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QImage extends EntityPathBase<Image> {
+
+    private static final long serialVersionUID = 418614167L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QImage image = new QImage("image");
+
+    public final QBaseEntity _super = new QBaseEntity(this);
+
+    //inherited
+    public final BooleanPath deleteAt = _super.deleteAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modDate = _super.modDate;
+
+    public final StringPath name = createString("name");
+
+    public final StringPath path = createString("path");
+
+    public final QPost post;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> regDate = _super.regDate;
+
+    public final StringPath size = createString("size");
+
+    public QImage(String variable) {
+        this(Image.class, forVariable(variable), INITS);
+    }
+
+    public QImage(Path<? extends Image> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QImage(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QImage(PathMetadata metadata, PathInits inits) {
+        this(Image.class, metadata, inits);
+    }
+
+    public QImage(Class<? extends Image> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.post = inits.isInitialized("post") ? new QPost(forProperty("post"), inits.get("post")) : null;
+    }
+
+}
+

--- a/src/main/generated/kr/co/skudeview/domain/QMember.java
+++ b/src/main/generated/kr/co/skudeview/domain/QMember.java
@@ -1,0 +1,75 @@
+package kr.co.skudeview.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QMember is a Querydsl query type for Member
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMember extends EntityPathBase<Member> {
+
+    private static final long serialVersionUID = 199618526L;
+
+    public static final QMember member = new QMember("member1");
+
+    public final QBaseEntity _super = new QBaseEntity(this);
+
+    public final StringPath address = createString("address");
+
+    public final DatePath<java.time.LocalDate> birthDate = createDate("birthDate", java.time.LocalDate.class);
+
+    public final ListPath<Company, QCompany> companies = this.<Company, QCompany>createList("companies", Company.class, QCompany.class, PathInits.DIRECT2);
+
+    //inherited
+    public final BooleanPath deleteAt = _super.deleteAt;
+
+    public final StringPath email = createString("email");
+
+    public final EnumPath<kr.co.skudeview.domain.enums.Gender> gender = createEnum("gender", kr.co.skudeview.domain.enums.Gender.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath major = createString("major");
+
+    public final ListPath<MemberSkill, QMemberSkill> memberSkills = this.<MemberSkill, QMemberSkill>createList("memberSkills", MemberSkill.class, QMemberSkill.class, PathInits.DIRECT2);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modDate = _super.modDate;
+
+    public final StringPath name = createString("name");
+
+    public final StringPath nickname = createString("nickname");
+
+    public final StringPath password = createString("password");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> regDate = _super.regDate;
+
+    public final EnumPath<kr.co.skudeview.domain.enums.Role> role = createEnum("role", kr.co.skudeview.domain.enums.Role.class);
+
+    public final StringPath telephone = createString("telephone");
+
+    public final StringPath univName = createString("univName");
+
+    public QMember(String variable) {
+        super(Member.class, forVariable(variable));
+    }
+
+    public QMember(Path<? extends Member> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QMember(PathMetadata metadata) {
+        super(Member.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/kr/co/skudeview/domain/QMemberLikePost.java
+++ b/src/main/generated/kr/co/skudeview/domain/QMemberLikePost.java
@@ -1,0 +1,65 @@
+package kr.co.skudeview.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QMemberLikePost is a Querydsl query type for MemberLikePost
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMemberLikePost extends EntityPathBase<MemberLikePost> {
+
+    private static final long serialVersionUID = 326282965L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QMemberLikePost memberLikePost = new QMemberLikePost("memberLikePost");
+
+    public final QBaseEntity _super = new QBaseEntity(this);
+
+    //inherited
+    public final BooleanPath deleteAt = _super.deleteAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final QMember member;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modDate = _super.modDate;
+
+    public final QPost post;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> regDate = _super.regDate;
+
+    public QMemberLikePost(String variable) {
+        this(MemberLikePost.class, forVariable(variable), INITS);
+    }
+
+    public QMemberLikePost(Path<? extends MemberLikePost> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QMemberLikePost(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QMemberLikePost(PathMetadata metadata, PathInits inits) {
+        this(MemberLikePost.class, metadata, inits);
+    }
+
+    public QMemberLikePost(Class<? extends MemberLikePost> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.member = inits.isInitialized("member") ? new QMember(forProperty("member")) : null;
+        this.post = inits.isInitialized("post") ? new QPost(forProperty("post"), inits.get("post")) : null;
+    }
+
+}
+

--- a/src/main/generated/kr/co/skudeview/domain/QMemberLikeReply.java
+++ b/src/main/generated/kr/co/skudeview/domain/QMemberLikeReply.java
@@ -1,0 +1,65 @@
+package kr.co.skudeview.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QMemberLikeReply is a Querydsl query type for MemberLikeReply
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMemberLikeReply extends EntityPathBase<MemberLikeReply> {
+
+    private static final long serialVersionUID = 1526383445L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QMemberLikeReply memberLikeReply = new QMemberLikeReply("memberLikeReply");
+
+    public final QBaseEntity _super = new QBaseEntity(this);
+
+    //inherited
+    public final BooleanPath deleteAt = _super.deleteAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final QMember member;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modDate = _super.modDate;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> regDate = _super.regDate;
+
+    public final QReply reply;
+
+    public QMemberLikeReply(String variable) {
+        this(MemberLikeReply.class, forVariable(variable), INITS);
+    }
+
+    public QMemberLikeReply(Path<? extends MemberLikeReply> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QMemberLikeReply(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QMemberLikeReply(PathMetadata metadata, PathInits inits) {
+        this(MemberLikeReply.class, metadata, inits);
+    }
+
+    public QMemberLikeReply(Class<? extends MemberLikeReply> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.member = inits.isInitialized("member") ? new QMember(forProperty("member")) : null;
+        this.reply = inits.isInitialized("reply") ? new QReply(forProperty("reply"), inits.get("reply")) : null;
+    }
+
+}
+

--- a/src/main/generated/kr/co/skudeview/domain/QMemberSkill.java
+++ b/src/main/generated/kr/co/skudeview/domain/QMemberSkill.java
@@ -1,0 +1,65 @@
+package kr.co.skudeview.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QMemberSkill is a Querydsl query type for MemberSkill
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMemberSkill extends EntityPathBase<MemberSkill> {
+
+    private static final long serialVersionUID = -250665709L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QMemberSkill memberSkill = new QMemberSkill("memberSkill");
+
+    public final QBaseEntity _super = new QBaseEntity(this);
+
+    //inherited
+    public final BooleanPath deleteAt = _super.deleteAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final QMember member;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modDate = _super.modDate;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> regDate = _super.regDate;
+
+    public final QSkill skill;
+
+    public QMemberSkill(String variable) {
+        this(MemberSkill.class, forVariable(variable), INITS);
+    }
+
+    public QMemberSkill(Path<? extends MemberSkill> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QMemberSkill(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QMemberSkill(PathMetadata metadata, PathInits inits) {
+        this(MemberSkill.class, metadata, inits);
+    }
+
+    public QMemberSkill(Class<? extends MemberSkill> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.member = inits.isInitialized("member") ? new QMember(forProperty("member")) : null;
+        this.skill = inits.isInitialized("skill") ? new QSkill(forProperty("skill")) : null;
+    }
+
+}
+

--- a/src/main/generated/kr/co/skudeview/domain/QMessage.java
+++ b/src/main/generated/kr/co/skudeview/domain/QMessage.java
@@ -1,0 +1,67 @@
+package kr.co.skudeview.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QMessage is a Querydsl query type for Message
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMessage extends EntityPathBase<Message> {
+
+    private static final long serialVersionUID = 1899250499L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QMessage message = new QMessage("message");
+
+    public final QBaseEntity _super = new QBaseEntity(this);
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final BooleanPath deleteAt = _super.deleteAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modDate = _super.modDate;
+
+    public final QMember receiver;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> regDate = _super.regDate;
+
+    public final QMember sender;
+
+    public QMessage(String variable) {
+        this(Message.class, forVariable(variable), INITS);
+    }
+
+    public QMessage(Path<? extends Message> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QMessage(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QMessage(PathMetadata metadata, PathInits inits) {
+        this(Message.class, metadata, inits);
+    }
+
+    public QMessage(Class<? extends Message> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.receiver = inits.isInitialized("receiver") ? new QMember(forProperty("receiver")) : null;
+        this.sender = inits.isInitialized("sender") ? new QMember(forProperty("sender")) : null;
+    }
+
+}
+

--- a/src/main/generated/kr/co/skudeview/domain/QPost.java
+++ b/src/main/generated/kr/co/skudeview/domain/QPost.java
@@ -1,0 +1,72 @@
+package kr.co.skudeview.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QPost is a Querydsl query type for Post
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QPost extends EntityPathBase<Post> {
+
+    private static final long serialVersionUID = -1648853276L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QPost post = new QPost("post");
+
+    public final QBaseEntity _super = new QBaseEntity(this);
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final BooleanPath deleteAt = _super.deleteAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final NumberPath<Integer> likeCount = createNumber("likeCount", Integer.class);
+
+    public final QMember member;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modDate = _super.modDate;
+
+    public final EnumPath<kr.co.skudeview.domain.enums.PostCategory> postCategory = createEnum("postCategory", kr.co.skudeview.domain.enums.PostCategory.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> regDate = _super.regDate;
+
+    public final StringPath title = createString("title");
+
+    public final NumberPath<Integer> viewCount = createNumber("viewCount", Integer.class);
+
+    public QPost(String variable) {
+        this(Post.class, forVariable(variable), INITS);
+    }
+
+    public QPost(Path<? extends Post> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QPost(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QPost(PathMetadata metadata, PathInits inits) {
+        this(Post.class, metadata, inits);
+    }
+
+    public QPost(Class<? extends Post> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.member = inits.isInitialized("member") ? new QMember(forProperty("member")) : null;
+    }
+
+}
+

--- a/src/main/generated/kr/co/skudeview/domain/QReply.java
+++ b/src/main/generated/kr/co/skudeview/domain/QReply.java
@@ -1,0 +1,69 @@
+package kr.co.skudeview.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QReply is a Querydsl query type for Reply
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QReply extends EntityPathBase<Reply> {
+
+    private static final long serialVersionUID = 426702118L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QReply reply = new QReply("reply");
+
+    public final QBaseEntity _super = new QBaseEntity(this);
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final BooleanPath deleteAt = _super.deleteAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final NumberPath<Integer> likeCount = createNumber("likeCount", Integer.class);
+
+    public final QMember member;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modDate = _super.modDate;
+
+    public final QPost post;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> regDate = _super.regDate;
+
+    public QReply(String variable) {
+        this(Reply.class, forVariable(variable), INITS);
+    }
+
+    public QReply(Path<? extends Reply> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QReply(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QReply(PathMetadata metadata, PathInits inits) {
+        this(Reply.class, metadata, inits);
+    }
+
+    public QReply(Class<? extends Reply> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.member = inits.isInitialized("member") ? new QMember(forProperty("member")) : null;
+        this.post = inits.isInitialized("post") ? new QPost(forProperty("post"), inits.get("post")) : null;
+    }
+
+}
+

--- a/src/main/generated/kr/co/skudeview/domain/QReport.java
+++ b/src/main/generated/kr/co/skudeview/domain/QReport.java
@@ -1,0 +1,71 @@
+package kr.co.skudeview.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QReport is a Querydsl query type for Report
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QReport extends EntityPathBase<Report> {
+
+    private static final long serialVersionUID = 342866552L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QReport report = new QReport("report");
+
+    public final QBaseEntity _super = new QBaseEntity(this);
+
+    //inherited
+    public final BooleanPath deleteAt = _super.deleteAt;
+
+    public final StringPath description = createString("description");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final QMember member;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modDate = _super.modDate;
+
+    public final QPost post;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> regDate = _super.regDate;
+
+    public final EnumPath<kr.co.skudeview.domain.enums.ReportCategory> reportCategory = createEnum("reportCategory", kr.co.skudeview.domain.enums.ReportCategory.class);
+
+    public final StringPath title = createString("title");
+
+    public QReport(String variable) {
+        this(Report.class, forVariable(variable), INITS);
+    }
+
+    public QReport(Path<? extends Report> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QReport(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QReport(PathMetadata metadata, PathInits inits) {
+        this(Report.class, metadata, inits);
+    }
+
+    public QReport(Class<? extends Report> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.member = inits.isInitialized("member") ? new QMember(forProperty("member")) : null;
+        this.post = inits.isInitialized("post") ? new QPost(forProperty("post"), inits.get("post")) : null;
+    }
+
+}
+

--- a/src/main/generated/kr/co/skudeview/domain/QSkill.java
+++ b/src/main/generated/kr/co/skudeview/domain/QSkill.java
@@ -1,0 +1,50 @@
+package kr.co.skudeview.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QSkill is a Querydsl query type for Skill
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QSkill extends EntityPathBase<Skill> {
+
+    private static final long serialVersionUID = 427797645L;
+
+    public static final QSkill skill = new QSkill("skill");
+
+    public final QBaseEntity _super = new QBaseEntity(this);
+
+    //inherited
+    public final BooleanPath deleteAt = _super.deleteAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modDate = _super.modDate;
+
+    public final StringPath name = createString("name");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> regDate = _super.regDate;
+
+    public QSkill(String variable) {
+        super(Skill.class, forVariable(variable));
+    }
+
+    public QSkill(Path<? extends Skill> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QSkill(PathMetadata metadata) {
+        super(Skill.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/kr/co/skudeview/domain/QUniversity.java
+++ b/src/main/generated/kr/co/skudeview/domain/QUniversity.java
@@ -1,0 +1,41 @@
+package kr.co.skudeview.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QUniversity is a Querydsl query type for University
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QUniversity extends EntityPathBase<University> {
+
+    private static final long serialVersionUID = 552603090L;
+
+    public static final QUniversity university = new QUniversity("university");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath major = createString("major");
+
+    public final StringPath univName = createString("univName");
+
+    public QUniversity(String variable) {
+        super(University.class, forVariable(variable));
+    }
+
+    public QUniversity(Path<? extends University> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QUniversity(PathMetadata metadata) {
+        super(University.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/kr/co/skudeview/domain/QVideo.java
+++ b/src/main/generated/kr/co/skudeview/domain/QVideo.java
@@ -1,0 +1,70 @@
+package kr.co.skudeview.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QVideo is a Querydsl query type for Video
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QVideo extends EntityPathBase<Video> {
+
+    private static final long serialVersionUID = 430503607L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QVideo video = new QVideo("video");
+
+    public final QBaseEntity _super = new QBaseEntity(this);
+
+    //inherited
+    public final BooleanPath deleteAt = _super.deleteAt;
+
+    public final StringPath duration = createString("duration");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modDate = _super.modDate;
+
+    public final StringPath name = createString("name");
+
+    public final StringPath path = createString("path");
+
+    public final QPost post;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> regDate = _super.regDate;
+
+    public final StringPath size = createString("size");
+
+    public QVideo(String variable) {
+        this(Video.class, forVariable(variable), INITS);
+    }
+
+    public QVideo(Path<? extends Video> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QVideo(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QVideo(PathMetadata metadata, PathInits inits) {
+        this(Video.class, metadata, inits);
+    }
+
+    public QVideo(Class<? extends Video> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.post = inits.isInitialized("post") ? new QPost(forProperty("post"), inits.get("post")) : null;
+    }
+
+}
+

--- a/src/main/java/kr/co/skudeview/controller/UniversityApiParseController.java
+++ b/src/main/java/kr/co/skudeview/controller/UniversityApiParseController.java
@@ -21,6 +21,9 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
 @Slf4j
 @RequiredArgsConstructor
 @RestController
@@ -30,6 +33,8 @@ public class UniversityApiParseController {
 
     @GetMapping("/api/load")
     public ResponseFormat<Void> loadJsonFromApi() {
+        List<University> universities = new ArrayList<>();
+        long start = System.nanoTime();
         String result = "";
         for (int j = 1; j <= 53; j++) {
             try {
@@ -55,7 +60,7 @@ public class UniversityApiParseController {
                     String univName = (String) object.get("학교명");
                     String major = (String) object.get("학부_과(전공)명");
                     University university = new University(univName, major);
-                    universityRepository.save(university);
+                    universities.add(university);
                 }
 
 
@@ -64,6 +69,10 @@ public class UniversityApiParseController {
                 return ResponseFormat.error(ResponseStatus.FAIL_BAD_REQUEST);
             }
         }
+        universityRepository.saveAll(universities);
+        long end = System.nanoTime();
+        System.out.println("수행시간: " + (end - start) + " ns");
+        System.out.println("universities.size = " + universities.size());
         return ResponseFormat.success(ResponseStatus.SUCCESS_OK);
     }
 }


### PR DESCRIPTION
1. springboot 3.x.x에 맞게 build.gradle 수정 기존 2.x.x버전에서 사용하던 방법과 위치가 다르므로 참고하였던 
   블로그 링크 첨가하겠습니다. https://lemontia.tistory.com/1089


  2 .UniversityApiParseController 최적화 : 기존 loop마다 save 해주던 로직에서 loop에서 리스트에 담아 saveAll()을 사용하는 로 
 직으로 변 경 - 기존 586초 소요되던 로직이 변경 후 27초 소요
